### PR TITLE
Update readme to reflect that several OS are supported + Add MacOS 13 runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -196,6 +196,8 @@ jobs:
             target: macos-10.15
           - os: macos-12
             target: macos-universal-10.15
+          - os: macos-13
+            target: macos-universal-10.15
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -19,7 +19,12 @@ Current known issues:
 
 ## Download
 
-MOD App only has builds for Windows 64bit for now, find them in the [releases section](https://github.com/moddevices/mod-app/releases).
+MOD App has builds for:
+* Linux - X86_64
+* MacOS - Universal Image
+* Windows - 64 bit
+
+You can find them in the [releases section](https://github.com/moddevices/mod-app/releases).
 
 ## Development
 


### PR DESCRIPTION
Modify readme to reflect that releases are available for
* Linux - X86_64
* MacOS - Universal Image
* Windows - 64 bit

Add Macos 13 github runner to workflow